### PR TITLE
feat: 버튼 컴포넌트 구현

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,15 +32,7 @@
     // 경고표시, 파일 확장자를 .ts나 .tsx 모두 허용함
     "react/jsx-filename-extension": ["warn", { "extensions": [".ts", ".tsx"] }],
     "no-useless-catch": "off", // 불필요한 catch 못쓰게 하는 기능 끔
-    "react/jsx-props-no-spreading": [
-      // spread 연산자
-      "error",
-      {
-        "html": "enforce",
-        "custom": "enforce",
-        "explicitSpread": "enforce",
-        "exceptions": ["input", "textarea", "Component"] // 이 경우에만 spread 연산자 사용 가능
-      }
-    ]
+    "react/jsx-props-no-spreading": "off",
+    "jsx-a11y/label-has-associated-control": "off"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,8 +1,3 @@
-// {
-//   "extends": "next/core-web-vitals"
-// }
-
-// 신규 추가
 {
   "root": true,
   "parser": "@typescript-eslint/parser",
@@ -33,6 +28,7 @@
     "react/jsx-filename-extension": ["warn", { "extensions": [".ts", ".tsx"] }],
     "no-useless-catch": "off", // 불필요한 catch 못쓰게 하는 기능 끔
     "react/jsx-props-no-spreading": "off",
-    "jsx-a11y/label-has-associated-control": "off"
+    "jsx-a11y/label-has-associated-control": "off",
+    "jsx-a11y/click-events-have-key-events": "off"
   }
 }

--- a/src/common/components/Button/Button.module.scss
+++ b/src/common/components/Button/Button.module.scss
@@ -1,0 +1,71 @@
+$duration: 0.3s;
+
+@mixin size($width, $padding) {
+  max-width: $width;
+  padding: $padding;
+}
+
+@mixin outlineColor($color) {
+  color: $color;
+  border: 0.1rem solid $color;
+  background: $color-white;
+  transition: $duration;
+  &:hover {
+    background: $color;
+    color: $color-white;
+  }
+}
+
+.button {
+  width: 100%;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  gap: .8rem;
+  border-radius: .6rem;
+}
+
+/* 배경색 */
+.solid {
+  color: $color-white;
+  background: $color-primary;
+  transition: $duration;
+  &:hover {
+    background: $color-primary;
+    color: $color-white;
+  }
+}
+
+.outline {
+  &.primary {
+    @include outlineColor($color-primary);
+  }
+  &.secondary {
+    @include outlineColor($color-blue-20);
+  }
+}
+
+/* 크기 */
+.large {
+  @include size(30.5rem, 1.4rem 0);
+  @include sopoqa-16-700;
+}
+
+.medium {
+  @include size(10.8rem, 1rem 0);
+  @include sopoqa-14-700;
+}
+
+.small {
+  @include size(8.2rem, 0.8rem 0);
+  @include sopoqa-12-400;
+}
+
+.button {
+  &:disabled {
+    color: $color-white;
+    border: none;
+    background-color: $color-gray-40;
+    cursor: not-allowed;
+  }
+}

--- a/src/common/components/Button/Button.module.scss
+++ b/src/common/components/Button/Button.module.scss
@@ -10,6 +10,7 @@ $duration: 0.3s;
   border: 0.1rem solid $color;
   background: $color-white;
   transition: $duration;
+
   &:hover {
     background: $color;
     color: $color-white;
@@ -21,8 +22,8 @@ $duration: 0.3s;
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  gap: .8rem;
-  border-radius: .6rem;
+  gap: 0.8rem;
+  border-radius: 0.6rem;
 }
 
 /* 배경색 */
@@ -30,8 +31,9 @@ $duration: 0.3s;
   color: $color-white;
   background: $color-primary;
   transition: $duration;
+
   &:hover {
-    background: $color-primary;
+    background: $color-red-40;
     color: $color-white;
   }
 }
@@ -40,6 +42,7 @@ $duration: 0.3s;
   &.primary {
     @include outlineColor($color-primary);
   }
+  
   &.secondary {
     @include outlineColor($color-blue-20);
   }
@@ -47,13 +50,21 @@ $duration: 0.3s;
 
 /* 크기 */
 .large {
-  @include size(30.5rem, 1.4rem 0);
+  @include size(35rem, 1.4rem 0);
   @include sopoqa-16-700;
+
+  &:disabled {
+    @include size(33.5rem, 1.4rem 0);
+  }
 }
 
 .medium {
   @include size(10.8rem, 1rem 0);
   @include sopoqa-14-700;
+
+  &:disabled {
+    @include size(9.5rem, 1rem 0);
+  }
 }
 
 .small {

--- a/src/common/components/Button/Button.tsx
+++ b/src/common/components/Button/Button.tsx
@@ -6,21 +6,32 @@ const cn = classNames.bind(styles);
 
 interface ButtonProps {
   children: ReactNode;
-  type: "submit" | "button" | "reset";
+  type?: "submit" | "button" | "reset";
   size: "large" | "medium" | "small";
   variant?: "solid" | "outline";
   color?: "primary" | "secondary";
+  className?: string;
   disabled?: boolean;
   onClick: () => void;
 }
 
-export default function Button({ children, type, size, variant, color, disabled, onClick, ...rest }: ButtonProps) {
+export default function Button({
+  children,
+  type = "button",
+  size,
+  variant = "solid",
+  color = "primary",
+  className,
+  disabled = false,
+  onClick,
+  ...rest
+}: ButtonProps) {
   return (
     <button
       // eslint-disable-next-line react/button-has-type
       type={type}
       disabled={disabled}
-      className={cn("button", size, variant, color)}
+      className={cn("button", size, variant, color, className)}
       onClick={onClick}
       {...rest}
     >
@@ -28,5 +39,3 @@ export default function Button({ children, type, size, variant, color, disabled,
     </button>
   );
 }
-
-Button.defaultProps = { variant: "solid", color: "primary", disabled: false } as Partial<ButtonProps>;

--- a/src/common/components/Button/Button.tsx
+++ b/src/common/components/Button/Button.tsx
@@ -4,7 +4,7 @@ import styles from "./Button.module.scss";
 
 const cn = classNames.bind(styles);
 
-interface Props {
+interface ButtonProps {
   children: ReactNode;
   type: "submit" | "button" | "reset";
   size: "large" | "medium" | "small";
@@ -14,7 +14,7 @@ interface Props {
   onClick: () => void;
 }
 
-export default function Button({ children, type, size, variant, color, disabled, onClick }: Props) {
+export default function Button({ children, type, size, variant, color, disabled, onClick }: ButtonProps) {
   return (
     <button
       // eslint-disable-next-line react/button-has-type
@@ -28,4 +28,4 @@ export default function Button({ children, type, size, variant, color, disabled,
   );
 }
 
-Button.defaultProps = { variant: "solid", color: "primary", disabled: false } as Partial<Props>;
+Button.defaultProps = { variant: "solid", color: "primary", disabled: false } as Partial<ButtonProps>;

--- a/src/common/components/Button/Button.tsx
+++ b/src/common/components/Button/Button.tsx
@@ -1,0 +1,31 @@
+import { ReactNode } from "react";
+import classNames from "classnames/bind";
+import styles from "./Button.module.scss";
+
+const cn = classNames.bind(styles);
+
+interface Props {
+  children: ReactNode;
+  type: "submit" | "button" | "reset";
+  size: "large" | "medium" | "small";
+  variant?: "solid" | "outline";
+  color?: "primary" | "secondary";
+  disabled?: boolean;
+  onClick: () => void;
+}
+
+export default function Button({ children, type, size, variant, color, disabled, onClick }: Props) {
+  return (
+    <button
+      // eslint-disable-next-line react/button-has-type
+      type={type}
+      disabled={disabled}
+      className={cn("button", size, variant, color)}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+}
+
+Button.defaultProps = { variant: "solid", color: "primary", disabled: false } as Partial<Props>;

--- a/src/common/components/Button/Button.tsx
+++ b/src/common/components/Button/Button.tsx
@@ -14,7 +14,7 @@ interface ButtonProps {
   onClick: () => void;
 }
 
-export default function Button({ children, type, size, variant, color, disabled, onClick }: ButtonProps) {
+export default function Button({ children, type, size, variant, color, disabled, onClick, ...rest }: ButtonProps) {
   return (
     <button
       // eslint-disable-next-line react/button-has-type
@@ -22,6 +22,7 @@ export default function Button({ children, type, size, variant, color, disabled,
       disabled={disabled}
       className={cn("button", size, variant, color)}
       onClick={onClick}
+      {...rest}
     >
       {children}
     </button>

--- a/src/common/components/index.ts
+++ b/src/common/components/index.ts
@@ -1,0 +1,2 @@
+export { default as Button } from "./Button/Button";
+export { default as Input } from "./Input/Input";

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -1,3 +1,5 @@
+$color-primary: #ea3c12;
+
 $color-black: #111322;
 $color-gray-50: #7d7986;
 $color-gray-40: #a4a1aa;

--- a/src/styles/fonts.scss
+++ b/src/styles/fonts.scss
@@ -19,6 +19,7 @@
   font-weight: 400;
   line-height: 1.6rem;
 }
+
 @mixin sopoqa-14-400 {
   font-family: "SpoqaHanSansNeo-Regular";
   font-size: 1.4rem;
@@ -33,6 +34,14 @@
   font-style: normal;
   font-weight: 400;
   line-height: 2.6rem;
+}
+
+@mixin sopoqa-14-700 {
+  font-family: "SpoqaHanSansNeo-Regular";
+  font-size: 1.4rem;
+  font-style: normal;
+  font-weight: 700;
+  line-height: normal;
 }
 
 @mixin sopoqa-16-700 {

--- a/src/styles/fonts.scss
+++ b/src/styles/fonts.scss
@@ -36,14 +36,6 @@
   line-height: 2.6rem;
 }
 
-@mixin sopoqa-14-700 {
-  font-family: "SpoqaHanSansNeo-Regular";
-  font-size: 1.4rem;
-  font-style: normal;
-  font-weight: 700;
-  line-height: normal;
-}
-
 @mixin sopoqa-16-700 {
   font-family: "SpoqaHanSansNeo-Regular";
   font-size: 1.6rem;


### PR DESCRIPTION
## #️⃣연관된 이슈

#19 

## 📝작업 내용

공용 버튼 컴포넌트 구현

- `colors.scss`와 `fonts.scss`에 변수 추가했어요
- `index.tsx`에서 export 해줬어요
- 버튼 스타일이 solid인건 메인 컬러 밖에 없는 것 같아서 solid는 메인 컬러 1가지 색상이고
- outline 스타일은 메인컬러와 블루컬러가 있는 것 같아서 outline은 두가지 색상을 사용할 수 있어요.

**props**
- `variant`: 배경색 있는 버튼과 없는 버튼
- `color`: 메인컬러와 블루

### 스크린샷 (선택)
![image](https://github.com/21-The-julge/the_julge/assets/72126893/3ed3ce1b-0e28-46ee-9f27-d5e887f5602a)
![image](https://github.com/21-The-julge/the_julge/assets/72126893/bbbc61d8-cf12-4bbd-98b9-2a6e44350008)

<img width="382" alt="스크린샷 2024-04-16 오후 6 58 01" src="https://github.com/21-The-julge/the_julge/assets/72126893/133f5b28-ef11-4ec9-b30a-bd95ab7ac912">




## 💬리뷰 요구사항(선택)

버튼 컴포넌트에서 eslint에러 처리한 것들이 있어요.
`// eslint-disable-next-line react/button-has-type` 로 에러를 처리한 부분이 있는데
eslint에서는 button type을 동적으로 말고 정적으로 지정하는 것을 강제하는 것 같더라구요
밑에 이슈 참고해서 처리했어요
https://github.com/jsx-eslint/eslint-plugin-react/issues/1846#issuecomment-614921516

optional props여서 default값을 원래 하던 방식으로 했는데 에러 나더라구요. 그래서 아래와 같이 처리했어요.
`Button.defaultProps = { variant: "solid", color: "primary", disabled: false } as Partial<Props>;`
https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/require-default-props.md
