### PR TITLE
refactor: table 컴포넌트 props type 변경

### DIFF
--- a/src/common/components/Table/Table.tsx
+++ b/src/common/components/Table/Table.tsx
@@ -1,4 +1,5 @@
 import classNames from "classnames/bind";
+import { ReactNode } from "react";
 import styles from "./Table.module.scss";
 
 interface TableProps {
@@ -6,7 +7,7 @@ interface TableProps {
     header: string;
     accessor: string;
   }[];
-  data: { [key: string]: any }[];
+  data: { id?: string; [key: string]: string | number | ReactNode }[];
 }
 const cn = classNames.bind(styles);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #79 

## 📝작업 내용

> type any에서 data: { id?: string; [key: string]: string | number | ReactNode }[]; 로 변경했습니다.

### 스크린샷 (선택)
![image](https://github.com/21-The-julge/the_julge/assets/114131736/d034756d-3a44-40f2-8397-5de62c99d0ca)
