### PR TITLE
hotfix: post p태그 중복 에러 해결

### DIFF
--- a/src/shared/components/Post/Post.tsx
+++ b/src/shared/components/Post/Post.tsx
@@ -57,9 +57,9 @@ export default function Post({
           </div>
         </div>
         <div className={cn("priceContent")}>
-          <p className={cn("price")}>
+          <div className={cn("price")}>
             {addComma(hourlyPay)}원<p className={cn("hidePrice")}>{addComma(hourlyPay)}원</p>
-          </p>
+          </div>
           <HighPriceRateBadge
             closed={closed}
             isPast={isPast}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #156 

## 📝작업 내용

![스크린샷 2024-04-29 203429](https://github.com/21-The-julge/the_julge/assets/114131736/6e08b144-faed-406c-a821-feb151009aff)

p태그 중복 오류 수정하니 이미지 일관되게 변했습니다

아직 구현 안된 곳 빼고, 오류는 발견되지 않았습니다

