### PR TITLE
fixed: 내 프로필 수정 페이지에서 이름과 연락처안나오는 버그 수정

### DIFF
--- a/src/common/components/Gnb/GlobalNavigationBar.module.scss
+++ b/src/common/components/Gnb/GlobalNavigationBar.module.scss
@@ -1,9 +1,13 @@
 .background {
   background-color: $color-white;
-
+  position: sticky;
+  top: 0;
+  left: 0;
+  right: 0;
   width: 100%;
   display: flex;
   justify-content: center;
+  z-index: $zindex-GNB;
 }
 
 .container {

--- a/src/common/components/Gnb/GlobalNavigationBar.module.scss
+++ b/src/common/components/Gnb/GlobalNavigationBar.module.scss
@@ -6,7 +6,6 @@
   right: 0;
   width: 100%;
   display: flex;
-  position: fixed;
   justify-content: center;
   z-index: $zindex-GNB;
 }

--- a/src/common/components/InputField/InputField.tsx
+++ b/src/common/components/InputField/InputField.tsx
@@ -47,7 +47,16 @@ export default forwardRef<HTMLInputElement, InputFieldProps>(function InputField
       {label && <Label label={label} htmlFor={name} required={rest.required} />}
       <div className={combinedClassName}>
         {prefix && <PrefixElement element={prefix} />}
-        <Input name={name} type={type} size={size} color={color} disabled={disabled} ref={ref} {...rest} />
+        <Input
+          name={name}
+          type={type}
+          size={size}
+          color={color}
+          disabled={disabled}
+          value={value}
+          ref={ref}
+          {...rest}
+        />
         {unit && <SuffixUnit unit={unit} />}
         {isError && <ErrorMessage message={errorMessage} />}
       </div>

--- a/src/page-layout/PostProfileEditLayout/components/PostProfileEditForm.tsx
+++ b/src/page-layout/PostProfileEditLayout/components/PostProfileEditForm.tsx
@@ -29,7 +29,6 @@ export default function PostNoticeForm({
   onOptionClick,
   inputValue,
 }: PostNoticeFormProps) {
-  console.log(inputValue);
   const disabled = ValidateInput({ inputValue });
 
   return (

--- a/src/page-layout/PostProfileEditLayout/components/PostProfileEditForm.tsx
+++ b/src/page-layout/PostProfileEditLayout/components/PostProfileEditForm.tsx
@@ -29,6 +29,7 @@ export default function PostNoticeForm({
   onOptionClick,
   inputValue,
 }: PostNoticeFormProps) {
+  console.log(inputValue);
   const disabled = ValidateInput({ inputValue });
 
   return (

--- a/src/styles/_zindex.scss
+++ b/src/styles/_zindex.scss
@@ -1,4 +1,3 @@
-// $zindex-dropdown: 1000;
 $zindex-sticky: 1020;
 $zindex-fixed: 1030;
 $zindex-modal-backdrop: 1040;

--- a/src/styles/_zindex.scss
+++ b/src/styles/_zindex.scss
@@ -7,3 +7,4 @@ $zindex-popover: 1060;
 $zindex-toast: 1060;
 $zindex-tooltip: 1070;
 $zindex-dropdown: 1080;
+$zindex-GNB: 1090;


### PR DESCRIPTION
## #️⃣연관된 이슈
#182 
> ex) #이슈번호, #이슈번호

## 📝작업 내용
내 프로필 수정 페이지에서 이름과 연락처가 받아와지는데 화면에 출력이 안돼서 input 태그 수정했습니다 !
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
