### PR TITLE
refactor: 가게 정보 상세 페이지 수정

### DIFF
--- a/src/page-layout/EditMyShopLayout/component/EditMyShop/EditMyShop.tsx
+++ b/src/page-layout/EditMyShopLayout/component/EditMyShop/EditMyShop.tsx
@@ -212,7 +212,7 @@ export default function EditMyShopLayout() {
           <div className={cn("imgContainer")}>
             <p className={cn("imgTitle")}>가게 이미지</p>
             <div className={cn("imgBox")}>
-              {img && <Image className={cn("img", { data })} src={img} alt="이미지 미리보기" />}
+              {img && <Image className={cn("img", { data })} fill src={img} alt="이미지 미리보기" />}
               <label className={cn("inputLabel", { data })} htmlFor="file">
                 <div className={cn("imgAddContainer")}>
                   <IcCamera width={32} height={32} fill="#FFFFFF" />

--- a/src/page-layout/MyShopLayout/component/RegisteredShop/RegisteredMyShop/RegisteredMyshop.tsx
+++ b/src/page-layout/MyShopLayout/component/RegisteredShop/RegisteredMyShop/RegisteredMyshop.tsx
@@ -16,6 +16,7 @@ export default function RegistseredMyShop({ shopId }: { shopId: string }) {
   const [lastRef, inView] = useInView();
 
   const { shopNoticeData, hasNextPage, fetchNextPage } = useInfinityQuery({ shopId });
+  const isShopNoticeData = shopNoticeData?.pages[0]?.count;
 
   useEffect(() => {
     if (inView && hasNextPage) {
@@ -46,5 +47,5 @@ export default function RegistseredMyShop({ shopId }: { shopId: string }) {
       </div>
     </div>
   );
-  return shopNoticeData ? RegisteredMyShopComponent : <Registser />;
+  return isShopNoticeData ? RegisteredMyShopComponent : <Registser />;
 }

--- a/src/shared/apis/apiType.ts
+++ b/src/shared/apis/apiType.ts
@@ -76,6 +76,7 @@ export interface ApiResponse {
   pageParams: [number];
   pages: Items[];
   items: Item[];
+  count: number;
 }
 
 export interface GetSpecificShopNoticeDataParams {


### PR DESCRIPTION
## #️⃣연관된 이슈
#188 
> ex) #이슈번호, #이슈번호

## 📝작업 내용
- 가게 정보 상세 페이지에서 등록한 공고가 없을 때 잘못된 UI가 나오는거 해결
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
